### PR TITLE
ECOM404RS-140/RSS-ECOMM-4_14-add displaying empty cart message and link to store

### DIFF
--- a/src/app/components/cart/cart.scss
+++ b/src/app/components/cart/cart.scss
@@ -145,6 +145,28 @@
           }
         }
       }
+
+      .empty-cart-message {
+        max-width: 18rem;
+        margin: auto;
+        line-height: 1.8;
+        text-align: center;
+
+        .store-link {
+          cursor: pointer;
+
+          font-size: 1.3rem;
+          color: var(--gold);
+          text-decoration: none;
+          text-shadow: 0 0 0.5rem var(--beige);
+
+          transition: color 0.2s ease;
+
+          &:hover {
+            color: var(--orange);
+          }
+        }
+      }
     }
 
     @media (width <=870px) {

--- a/src/app/components/cart/cart.ts
+++ b/src/app/components/cart/cart.ts
@@ -1,5 +1,6 @@
 import BaseComponent from '@common-components/base-component';
 import {
+  createA,
   createButton,
   createDiv,
   createH2,
@@ -26,6 +27,7 @@ class CartComponent extends BaseComponent<HTMLDivElement> {
   private readonly cartButtons: BaseComponent<HTMLDivElement>;
   private readonly clearButton: BaseComponent<HTMLButtonElement>;
   private readonly checkoutButton: BaseComponent<HTMLButtonElement>;
+  private readonly emptyCartMessage: BaseComponent<HTMLDivElement>;
 
   private items: ReturnType<typeof CartItem>[] = [];
 
@@ -44,6 +46,7 @@ class CartComponent extends BaseComponent<HTMLDivElement> {
     this.cartButtons = createDiv(undefined, 'cart-buttons');
     this.clearButton = this.createClearButton();
     this.checkoutButton = this.createCheckoutButton();
+    this.emptyCartMessage = createDiv(undefined, 'empty-cart-message');
 
     this.init();
 
@@ -171,14 +174,32 @@ class CartComponent extends BaseComponent<HTMLDivElement> {
         this.cartItems.removeChildren();
         this.items = [];
         const lineItems = response.body?.lineItems;
-        lineItems?.map((lineItem) => {
-          if (lineItem) {
+
+        if (lineItems && lineItems.length > 0) {
+          for (const lineItem of lineItems) {
             const cartItem = CartItem(lineItem);
             this.items.push(cartItem);
             cartItem.appendTo(this.cartItems.getElement());
           }
-        });
+        } else {
+          this.renderEmptyCartMessage();
+        }
       });
+  }
+
+  private renderEmptyCartMessage(): void {
+    this.emptyCartMessage.removeChildren();
+    const messageText = createP(undefined, 'message-text');
+    messageText.setText('Your cart is currently empty. Start your shopping journey in ');
+
+    const storeLink = createA(undefined, 'store-link');
+    storeLink.setText('the Store');
+    storeLink.setAttribute('href', '#/store');
+
+    storeLink.appendTo(messageText.getElement());
+    messageText.appendTo(this.emptyCartMessage.getElement());
+
+    this.emptyCartMessage.appendTo(this.cartItems.getElement());
   }
 }
 


### PR DESCRIPTION
1. Summary: add displaying empty cart message and link to store
2. Jira task: [link](https://404-team-jira.atlassian.net/browse/ECOM404RS-140?atlOrigin=eyJpIjoiNTEwZjI0NmIyOGJlNDM4YWIwMjI0NTNiM2JlZjg3MjEiLCJwIjoiaiJ9)
3. RSSchool task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_14.md)
4. (optional) Screenshot: 
![Снимок экрана 2025-06-17 130946](https://github.com/user-attachments/assets/2ea8d5d2-cd07-41f4-aa87-7bfec3e3cb06)

5. (optional) Detailed description:

- [x] A clear and friendly message is displayed when the shopping cart is empty
- [x] The message is clearly visible and located within the area where cart items would typically be displayed
- [x] The link is functional and directs users to the product catalog when clicked